### PR TITLE
custom node number for distribute training

### DIFF
--- a/GNNI.ecl
+++ b/GNNI.ecl
@@ -144,12 +144,13 @@ EXPORT GNNI := MODULE
   
   SHARED INTEGER getEffNodesNumber(nodeNumber) := FUNCTION
     /*
-    nodeNumber: default value = -1 (meaning distribute to all nodes)
-                if totalAvailableNode<nodeNumber<0 then fallback to totalAvailableNodes, 
+    nodeNumber: default value = 0 (meaning distribute to all nodes)
+                if totalAvailableNode<nodeNumber<=0 then fallback to totalAvailableNodes,
     */
     totalAvailableNodes := Thorlib.nodes();
-    eNodeNumber := IF(nodeNumber<0, totalAvailableNodes, nodeNumber);
-    return IF(totalAvailableNodes>eNodeNumber, eNodeNumber, totalAvailableNodes);
+    eNodeNumber := IF(nodeNumber>0, nodeNumber, totalAvailableNodes);
+    // clipping eNodeNumber to totalAvailableNodes
+    return IF(eNodeNumber<totalAvailableNodes, eNodeNumber, totalAvailableNodes);
   END;
 
   SHARED UNSIGNED4 getToken(UNSIGNED4 lastToken) := EMBED(Python)
@@ -208,14 +209,13 @@ EXPORT GNNI := MODULE
     * @param nodes (optional) nodes number to run the program
     * @return A model token to be used in subsequent GNNI calls.
     */
-  EXPORT UNSIGNED4 DefineModel(UNSIGNED4 sess, SET OF STRING ldef, STRING cdef = '', Integer nodes=-1) := FUNCTION
+  EXPORT UNSIGNED4 DefineModel(UNSIGNED4 sess, SET OF STRING ldef, STRING cdef = '') := FUNCTION
     mdef1 := DATASET(COUNT(ldef), TRANSFORM(kString, SELF.typ := kStrType.layer,
                                             SELF.id  := COUNTER,
                                             SELF.text := ldef[COUNTER]));
     mdef2 := DATASET([{0, COUNT(ldef)+1, kStrType.compile, cdef}], kString);
     mdef := IF(LENGTH(cdef) > 0, mdef1 + mdef2, mdef1);
-    eNodes := getEffNodesNumber(nodes);
-    mdefRepl0 := SORT(DISTRIBUTE(mdef, eNodes), id, LOCAL);
+    mdefRepl0 := SORT(DISTRIBUTE(mdef, ALL), id, LOCAL);
     mdefRepl := PROJECT(NOCOMBINE(mdefRepl0), TRANSFORM(RECORDOF(LEFT), SELF.nodeId := nodeId, SELF := LEFT), LOCAL);
     kstatus := ASSERT(Keras.DefineModel(mdefRepl, sess), LENGTH(text) = 0, 'DefineModel Exception: ' + text);
     status := reduceResults(kstatus);
@@ -258,11 +258,9 @@ EXPORT GNNI := MODULE
                                    DATASET(FuncLayerDef) lDefs,
                                    SET OF STRING inputs,
                                    SET OF STRING outputs,
-                                   STRING cdef = '', 
-                                   INTEGER nodes=-1) := FUNCTION
+                                   STRING cdef = '') := FUNCTION
     // Distribute the lDefs to all nodes to make sure that the model is defined on each node
-    eNodes := getEffNodesNumber(nodes);
-    lDefsRepl := DISTRIBUTE(lDefs, eNodes);
+    lDefsRepl := DISTRIBUTE(lDefs, ALL);
     kstatus := ASSERT(Keras.DefineFuncModel(lDefsRepl, sess, inputs, outputs, cdef), LENGTH(text) = 0, 'DefineFuncModel Exception: ' + text);
     status := reduceResults(kstatus);
     // Extract the Keras modelId from the id field of the returned status.  Each node should have the
@@ -572,6 +570,88 @@ EXPORT GNNI := MODULE
     finalWts := LOOP(initWts, numEpochs, LEFT.nodeId < 999999, EXISTS(ROWS(LEFT)), doEpoch(ROWS(LEFT), COUNTER));
     RETURN IF(EXISTS(finalWts), getToken(model + numEpochs * numEpochs), 0);
   END; // Fit
+
+  EXPORT UNSIGNED4 nNodeFit(UNSIGNED4 model_,
+                      DATASET(t_Tensor) x_,
+                      DATASET(t_Tensor) y_,
+                      UNSIGNED4 batchSize_ = 512,
+                      UNSIGNED4 numEpochs_ = 1,
+                      REAL trainToLoss_ = 0,
+                      REAL learningRateReduction_ = 1.0,
+                      REAL batchSizeReduction_ = 1.0,
+                      UNSIGNED4 localBatchSize_ = 32,
+                      INTEGER limitNodes_=0) := FUNCTION
+    effNodes := getEffNodesNumber(limitNodes_);
+
+    UNSIGNED4 partialFit(
+      UNSIGNED4 model,
+      DATASET(t_Tensor) x,
+      DATASET(t_Tensor) y,
+      UNSIGNED4 batchSize = 512,
+      UNSIGNED4 numEpochs = 1,
+      REAL trainToLoss = 0,
+      REAL learningRateReduction = 1.0,
+      REAL batchSizeReduction = 1.0,
+      UNSIGNED4 localBatchSize = 32,
+      INTEGER limitNodes) := FUNCTION
+
+        kModelId := model DIV kerasIdFactor;
+        // Get the initial weights to use
+        initWts0 := GetWeights(model);
+        // We get the weights from the first node and then copy them to all nodes
+        // so that everybody starts with the same weights
+        initWts := Tensor.R4.Replicate(initWts0, limitNodes);
+        // Align the X and Y tensor lists so that we will get the corresponding records on the same nodes
+        // for each input and output tensor.
+        maxInputWi := MAX(x, wi);
+        // Change the wi's for outputs (y) so that they are after the input wi's
+        y1 := PROJECT(y, TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi + maxInputWi, SELF := LEFT), LOCAL);
+        aligned := Tensor.R4.AlignTensors(x + y1);
+        // Now change the Y's wi back to the original numbers
+        xAl := aligned(wi <= maxInputWi);
+        yAl := PROJECT(aligned(wi > maxInputWi), TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi - maxInputWi, SELF := LEFT), LOCAL);
+        totalRecords := Tensor.R4.GetRecordCount(yAl);
+        DATASET(t_Tensor) doEpoch(DATASET(t_Tensor) wts1, UNSIGNED epochNum) := FUNCTION
+          // Calculate the Learning Rate for this Epoch (eLR)
+          eLR := 1 - ((epochNum - 1) / (numEpochs - 1) * (1 - learningRateReduction));
+          eBatchSize := MAX(TRUNCATE((1 - ((epochNum -1) / (numEpochs -1) * (1 - batchSizeReduction))) * batchSize), 512);
+          batchesPerEpoch := ROUNDUP(totalRecords / effNodes / eBatchSize);
+          DATASET(t_Tensor) doBatch(DATASET(t_Tensor) wts2, UNSIGNED batchNum) := FUNCTION
+            // Train the model and Get the weight changes from each node
+            batchPos := (batchNum-1) * eBatchSize + 1;
+            xBatch := int.TensExtract(xAl, batchPos, eBatchSize);
+            yBatch := int.TensExtract(yAl, batchPos, eBatchSize);
+            wtChanges0 := IF(EXISTS(yBatch), Keras.FitBatch(wts2, xBatch, yBatch, model, epochNum, kModelId, localBatchSize, eLR), DATASET([], t_Tensor));
+            // Move all the changes for a given wi and slice to the same node.  Each
+            // node has a set of wi/sliceIds to roll up.  Note that the original
+            // weights are already replicated to all nodes.
+            wtChanges := DISTRIBUTE(wtChanges0, wi + sliceId);
+            // Sum up the original weights (de-replicated) and all changes for each wi and slice
+            newWts := rollUpdates(wts2((wi + sliceId) % effNodes = nodeId), wtChanges);
+            // Note: newWts have been replicated to all nodes by rollUpdates.
+            batchLoss := IF(EXISTS(newWts), GetLoss(model + (batchesPerEpoch * (epochNum-1)) + batchNum), 1.0);
+            logProgress2 := Syslog.addWorkunitInformation('Training Status (2): ModelId = ' +
+                    kModelId + ', Epoch = ' + epochNum + ', Batch = ' + batchNum + ', Loss = ' + batchLoss);
+            RETURN newWts;
+          END;
+          epochWts0 := LOOP(wts1, batchesPerEpoch, doBatch(ROWS(LEFT), COUNTER));
+          epochLoss := IF(EXISTS(epochWts0), GetLoss(model + (batchesPerEpoch * (epochNum-1))), 1.0);
+          logProgress := Syslog.addWorkunitInformation('Training Status: ModelId = ' +
+                          kModelId + ', Epoch = ' + epochNum + ', LR = ' + ROUND(eLR, 2) + ', bs = ' + eBatchSize + ', Loss = ' + epochLoss);
+          // If we've met the trainToLoss goal, mark as final to end the LOOP.  We mark the node id as
+          // 999999 to indicate that we are done.
+          markFinal := PROJECT(epochWts0, TRANSFORM(RECORDOF(LEFT), SELF.nodeId := 999999, SELF := LEFT));
+          epochWts := IF(epochLoss < trainToLoss, markFinal, epochWts0);
+          RETURN WHEN(epochWts, logProgress);
+        END;
+        finalWts := LOOP(initWts, numEpochs, LEFT.nodeId < 999999, EXISTS(ROWS(LEFT)), doEpoch(ROWS(LEFT), COUNTER));
+        RETURN IF(EXISTS(finalWts), getToken(model + numEpochs * numEpochs), 0);
+        END;
+
+    RETURN IF(effnodes<nNodes, partialFit(model_, x_, y_, batchSize_, numEpochs_, trainToLoss_, learningRateReduction_, batchSizeReduction_, localBatchSize_, limitNodes_), Fit(
+        model_, x_, y_, batchSize_, numEpochs_, trainToLoss_, learningRateReduction_, batchSizeReduction_, localBatchSize_));
+
+  END; // nNodeFit
   /**
     * Determine the loss and other metrics in order to evaluate
     * the model.
@@ -734,6 +814,21 @@ EXPORT GNNI := MODULE
     yT := NF2Tensor(y);
     RETURN Fit(model, xT, yT, batchSize, numEpochs, trainToLoss, learningRateReduction,
                 batchSizeReduction, localBatchSize);
+  END;
+  
+  EXPORT UNSIGNED4 nNodeFitNF(UNSIGNED4 model,
+                    DATASET(NumericField) x,
+                    DATASET(NumericField) y,
+                    UNSIGNED4 batchSize = 512,
+                    UNSIGNED4 numEpochs = 1,
+                    REAL trainToLoss = 0,
+                    REAL learningRateReduction = 1.0,
+                    REAL batchSizeReduction = 1.0,
+                    UNSIGNED4 localBatchSize = 32, INTEGER limitNodes_=0) := FUNCTION
+    xT := NF2Tensor(x);
+    yT := NF2Tensor(y);
+    RETURN nNodeFit(model, xT, yT, batchSize, numEpochs, trainToLoss, learningRateReduction,
+                batchSizeReduction, localBatchSize, limitNodes_);
   END;
   /**
     * Evaluate a model with 2 dimensional input and output using NumericField

--- a/GNNI.ecl
+++ b/GNNI.ecl
@@ -145,7 +145,7 @@ EXPORT GNNI := MODULE
   SHARED INTEGER getEffNodesNumber(nodeNumber) := FUNCTION
     /*
     nodeNumber: default value = -1 (meaning distribute to all nodes)
-                if nodeNumber > totalAvailableNode then fallback to all nodes, 
+                if totalAvailableNode<nodeNumber<0 then fallback to totalAvailableNodes, 
     */
     totalAvailableNodes := Thorlib.nodes();
     eNodeNumber := IF(nodeNumber<0, totalAvailableNodes, nodeNumber);
@@ -205,6 +205,7 @@ EXPORT GNNI := MODULE
     *         model.add().  Each string defines one layer of the model.
     * @param cdef (optional) A python string as would be passed to Keras model.compile(...).
     *         This line should begin with "compile".  Model is implicit here.
+    * @param nodes (optional) nodes number to run the program
     * @return A model token to be used in subsequent GNNI calls.
     */
   EXPORT UNSIGNED4 DefineModel(UNSIGNED4 sess, SET OF STRING ldef, STRING cdef = '', Integer nodes=-1) := FUNCTION

--- a/Tensor.ecl
+++ b/Tensor.ecl
@@ -390,8 +390,19 @@ EXPORT Tensor
       *   contained N slices, the new dataset will contain N x nNodes
       *   slices.
       */
-    EXPORT DATASET(t_Tensor) Replicate(DATASET(t_Tensor) tens) := FUNCTION
-      tensD := DISTRIBUTE(tens, ALL);
+    EXPORT DATASET(t_Tensor) Replicate(DATASET(t_Tensor) tens, INTEGER limitNodes=0) := FUNCTION
+       
+      DATASET(t_Tensor) distPartial(DATASET(t_Tensor) t_in, INTEGER numNodes) := FUNCTION 
+        t0 := NORMALIZE(
+          t_in, 
+          numNodes, 
+          TRANSFORM(RECORDOF(LEFT),
+            SELF.nodeId := COUNTER-1,
+            SELF := LEFT), LOCAL);
+        t1 := DISTRIBUTE(t0, nodeId);
+        return t1;
+      END;
+      tensD := IF(limitNodes>0, distPartial(tens, limitNodes), DISTRIBUTE(tens, ALL));
       tensP := PROJECT(NOCOMBINE(tensD), TRANSFORM(RECORDOF(LEFT),
                                               SELF.nodeId := node,
                                               SELF := LEFT), LOCAL);

--- a/Tensor.ecl
+++ b/Tensor.ecl
@@ -680,7 +680,7 @@ EXPORT Tensor
       contentsDS := SORT(NOCOMBINE(contentsD), indexes[1], LOCAL);
       slices0 := makeSlices(contentsDS, wi, shape, adjShape, t_TensType.R4, elemSize, sliceElems);
       // If not replicated, slices are already correctly distributed (i.e. by wi and sliceId)
-      slices1 := IF(replicated, Replicate(slices0), PROJECT(slices0, TRANSFORM(RECORDOF(LEFT),
+      slices1 := IF(replicated, Replicate(slices0, limitNodes:=effNodes), PROJECT(slices0, TRANSFORM(RECORDOF(LEFT),
                                                             SELF.nodeId := node,
                                                             SELF := LEFT), LOCAL));
       slices := SORT(slices1, sliceId, LOCAL);

--- a/Test/ClassicTest.ecl
+++ b/Test/ClassicTest.ecl
@@ -17,9 +17,9 @@ IMPORT GNN.Internal AS Int;
 IMPORT Std.System.Thorlib;
 t_Tensor := Tensor.R4.t_Tensor;
 TensData := Tensor.R4.TensData;
-
+///opt/HPCCSystems/9.0.6/clienttools/bin
 RAND_MAX := POWER(2,32) -1;
-
+nodes := 2;
 // Test parameters
 trainCount := 10000;
 testCount := 1000;
@@ -132,7 +132,7 @@ s := GNNI.GetSession();
 // DefineModel is dependent on the Session
 //   ldef contains the Python definition for each Keras layer
 //   compileDef contains the Keras compile statement.
-mod := GNNI.DefineModel(s, ldef, compileDef);
+mod := GNNI.DefineModel(s, ldef, compileDef, nodes);
 // GetWeights returns the initialized weights that have been synchronized across all nodes.
 wts := GNNI.GetWeights(mod);
 

--- a/Test/ClassificationTest.ecl
+++ b/Test/ClassificationTest.ecl
@@ -157,7 +157,8 @@ OUTPUT(wts, NAMED('InitWeights'));
 // Fit trains the models, given training X and Y data.  BatchSize is not the Keras batchSize,
 // but defines how many records are processed on each node before synchronizing the weights
 // Note that we use the NF form of Fit since we are using NumericField for I / o.
-mod2 := GNNI.FitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs);
+//mod2 := GNNI.FitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs);
+mod2 := GNNI.nNodeFitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs, limitNodes_ := 0);
 
 OUTPUT(mod2, NAMED('mod2'));
 

--- a/Test/ClassificationTest.ecl
+++ b/Test/ClassificationTest.ecl
@@ -94,32 +94,56 @@ test := PROJECT(test0, TRANSFORM(RECORDOF(LEFT), SELF.y := targetFunc(LEFT.x[1],
 
 // Break the training and test data into X (independent) and Y (dependent) data sets.
 // Format as NumericField data.
-trainX := NORMALIZE(train, featureCount, TRANSFORM(NumericField,
+
+trainX0 := NORMALIZE(train, featureCount, TRANSFORM(NumericField,
                             SELF.wi := 1,
                             SELF.id := LEFT.id,
                             SELF.number := COUNTER,
                             SELF.value := LEFT.x[COUNTER]));
-trainY := NORMALIZE(train, classCount, TRANSFORM(NumericField,
+trainY0 := NORMALIZE(train, classCount, TRANSFORM(NumericField,
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.y[COUNTER]));
+trainX1 := Tensor.R4.dat.fromMatrix(TrainX0);
+trainY1 := Tensor.R4.dat.fromMatrix(TrainY0);
+
+trainX := Tensor.R4.MakeTensor([0, featureCount], trainX1, limitNodes:=2);
+trainY := Tensor.R4.MakeTensor([0, classCount], trainY1, limitNodes:=2);
+
+maxInputWi := MAX(trainX, wi);
+// Change the wi's for outputs (y) so that they are after the input wi's
+y1 := PROJECT(trainY, TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi + maxInputWi, SELF := LEFT), LOCAL);
+aligned := Tensor.R4.AlignTensors(trainX + y1, limitNodes:=2);
+// Now change the Y's wi back to the original numbers
+xAl := aligned(wi <= maxInputWi);
+yAl := PROJECT(aligned(wi > maxInputWi), TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi - maxInputWi, SELF := LEFT), LOCAL);
+
+totalRecords := Tensor.R4.GetRecordCount(yAl);
+eLR := 1 - ((2 - 1) / (3 - 1) * (1 - 1.0));
+eBatchSize := MAX(TRUNCATE((1 - ((2.0 -1) / (numEpochs -1) * (1 - 1.0))) * batchSize), 512);
+batchesPerEpoch := ROUNDUP(totalRecords / 2.0 / eBatchSize);
+          
+// OUTPUT(xAl, NAMED('XAL'));
+// OUTPUT(YAl, NAMED('YAL'));
+// OUTPUT(trainX0, NAMED('X1_0'));
+// OUTPUT(trainY0, NAMED('y1_o'));
+// OUTPUT(trainX, NAMED('X'));
+// OUTPUT(trainY, NAMED('y'));
+
+testX := NORMALIZE(test, featureCount, TRANSFORM(NumericField, // 5
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.x[COUNTER]));
+testY := NORMALIZE(test, classCount, TRANSFORM(NumericField,  // 3
                             SELF.wi := 1,
                             SELF.id := LEFT.id,
                             SELF.number := COUNTER,
                             SELF.value := LEFT.y[COUNTER]));
 
-OUTPUT(trainX, NAMED('X1'));
-OUTPUT(trainY, NAMED('y1'));
-
-testX := NORMALIZE(test, featureCount, TRANSFORM(NumericField,
-                            SELF.wi := 1,
-                            SELF.id := LEFT.id,
-                            SELF.number := COUNTER,
-                            SELF.value := LEFT.x[COUNTER]));
-testY := NORMALIZE(test, classCount, TRANSFORM(NumericField,
-                            SELF.wi := 1,
-                            SELF.id := LEFT.id,
-                            SELF.number := COUNTER,
-                            SELF.value := LEFT.y[COUNTER]));
-
-
+OUTPUT(count(trainY[1].densedata), Named('TestY1_Count'));
+OUTPUT(count(trainY[2].densedata), Named('TestY2_Count'));
 // ldef provides the set of Keras layers that form the neural network.  These are
 // provided as strings representing the Python layer definitions as would be provided
 // to Keras.  Note that the symbol 'tf' is available for use (import tensorflow as tf), as is
@@ -158,9 +182,10 @@ OUTPUT(wts, NAMED('InitWeights'));
 // but defines how many records are processed on each node before synchronizing the weights
 // Note that we use the NF form of Fit since we are using NumericField for I / o.
 //mod2 := GNNI.FitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs);
-mod2 := GNNI.nNodeFitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs, limitNodes_ := 2);
 
-OUTPUT(mod2, NAMED('mod2'));
+mod2 := GNNI.nNodeFit(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs, limitNodes := 2);
+
+//OUTPUT(mod2, NAMED('mod2'));
 
 // GetLoss returns the average loss for the final training epoch
 losses := GNNI.GetLoss(mod2);
@@ -169,7 +194,7 @@ losses := GNNI.GetLoss(mod2);
 // compile line.  This is the NumericField form of EvaluateMod.
 metrics := GNNI.EvaluateNF(mod2, testX, testY);
 
-OUTPUT(metrics, NAMED('metrics'));
+//OUTPUT(metrics, NAMED('metrics'));
 
 // PredictNF computes the neural network output given a set of inputs.
 // This is the NumericField form of Predict. Note that these predictions are
@@ -179,5 +204,5 @@ OUTPUT(metrics, NAMED('metrics'));
 // Utils.Probabilities2Class.
 preds := GNNI.PredictNF(mod2, testX);
 
-OUTPUT(testY, ALL, NAMED('testDat'));
-OUTPUT(preds, NAMED('predictions'));
+//OUTPUT(testY, ALL, NAMED('testDat'));
+//OUTPUT(preds, NAMED('predictions'));

--- a/Test/ClassificationTest.ecl
+++ b/Test/ClassificationTest.ecl
@@ -158,7 +158,7 @@ OUTPUT(wts, NAMED('InitWeights'));
 // but defines how many records are processed on each node before synchronizing the weights
 // Note that we use the NF form of Fit since we are using NumericField for I / o.
 //mod2 := GNNI.FitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs);
-mod2 := GNNI.nNodeFitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs, limitNodes_ := 0);
+mod2 := GNNI.nNodeFitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs, limitNodes_ := 2);
 
 OUTPUT(mod2, NAMED('mod2'));
 

--- a/Test/SetupTest.ecl
+++ b/Test/SetupTest.ecl
@@ -12,6 +12,8 @@ IMPORT Std.System.Thorlib;
 
 nNodes := Thorlib.nodes();
 nodeId := Thorlib.node();
+output(nNodes, Named('nNodes'));
+output(nodeId, Named('nodeId'));
 testRec := RECORD
   UNSIGNED node;
   STRING tf_version;

--- a/Test/nNodeClassificationTest.ecl
+++ b/Test/nNodeClassificationTest.ecl
@@ -1,0 +1,204 @@
+﻿/*##############################################################################
+## HPCC SYSTEMS software Copyright (C) 2019 HPCC Systems.  All rights reserved.
+############################################################################## */
+/**
+  * Test GNNI with a classic classification neural network.
+  * This test uses synthetic data generated internally.
+  * It shows how GNN is used for classification using a simple
+  * 2 dimensional (classic) input and output.
+  * GNNI supports NumericField matrices as input and output
+  * for 2D problems, as well as the more flexible Tensor
+  * input and output.
+  * This test (arbitrarily) uses NumericField I/O instead of
+  * Tensors in order to validate and illustrate this capability.
+  * It could have used 2D Tensors.  Use of 2D Tensors is
+  * demonstrated in ClassicTest.ecl.
+  * For a classification example using higher dimensional tensors
+  * and more complex neural networks, see:
+  * HARTests/harLSTM.ecl or HARTests/harCNN_LSTM.ecl.
+  * These examples also illustrate how to use the one-hot encoding
+  * / decoding utilities.
+  */
+IMPORT Python3 AS Python;
+IMPORT $.^ AS GNN;
+IMPORT GNN.Tensor;
+IMPORT GNN.Internal.Types AS iTypes;
+IMPORT GNN.Types;
+IMPORT GNN.GNNI;
+IMPORT GNN.Internal AS Int;
+IMPORT ML_Core AS mlc;
+
+NumericField := mlc.Types.NumericField;
+
+// Prepare training data
+RAND_MAX := POWER(2,32) -1;
+
+// Test parameters
+trainCount := 1000;
+testCount := 100;
+featureCount := 5;
+classCount := 3;
+numEpochs := 5;
+batchSize := 128;
+// End of Test Parameters
+
+// Prepare training data.
+// We use 5 inputs (X) and a one hot encoded output (Y) with 3 classes
+// (i.e. 3 outputs).
+trainRec := RECORD
+  UNSIGNED8 id;
+  SET OF REAL4 x;
+  SET OF REAL4 y;
+END;
+
+// The target function maps a set of X features into a Y value,
+// which is a threshold on a polynomial function of X.
+// Note that we are effectively doing a One Hot encoding here, since we
+// return a set of Y values, one for each class, with only one value
+// being one and the rest zero.
+// If we were working with tensors here, we could have used a class
+// label and then called Utils.ToOneHot to encode it.
+SET OF REAL4 targetFunc(REAL4 x1, REAL4 x2, REAL4 x3, REAL4 x4, REAL4 x5) := FUNCTION
+  rslt0 := TANH(.5 * POWER(x1, 4) - .4 * POWER(x2, 3) + .3 * POWER(x3,2) - .2 * x4 + .1 * x5);
+  rslt := MAP(rslt0 > -.25 => [1,0,0], rslt0 < .25 => [0,1,0], [0,0,1]);
+  RETURN rslt;
+END;
+
+// Build the training data
+train0 := DATASET(trainCount, TRANSFORM(trainRec,
+                      SELF.id := COUNTER,
+                      SELF.x := [(RANDOM() % RAND_MAX) / (RAND_MAX / 2) - 1,
+                                  (RANDOM() % RAND_MAX) / (RAND_MAX / 2) - 1,
+                                  (RANDOM() % RAND_MAX) / (RAND_MAX / 2) - 1,
+                                  (RANDOM() % RAND_MAX) / (RAND_MAX / 2) - 1,
+                                  (RANDOM() % RAND_MAX) / (RAND_MAX / 2) - 1],
+                      SELF.y := [])
+                      );
+// Be sure to compute Y in a second step.  Otherewise, the RANDOM() will be executed twice and the Y will be based
+// on different values than those assigned to X.  This is an ECL quirk that is not easy to fix.
+train := PROJECT(train0, TRANSFORM(RECORDOF(LEFT), SELF.y := targetFunc(LEFT.x[1], LEFT.x[2], LEFT.x[3], LEFT.x[4], LEFT.x[5]), SELF := LEFT));
+OUTPUT(train, NAMED('trainData'));
+
+// Build the test data.  Same process as the training data.
+test0 := DATASET(testCount, TRANSFORM(trainRec,
+                      SELF.id := COUNTER,
+                      SELF.x := [(RANDOM() % RAND_MAX) / RAND_MAX -.5,
+                                  (RANDOM() % RAND_MAX) / RAND_MAX -.5,
+                                  (RANDOM() % RAND_MAX) / RAND_MAX -.5,
+                                  (RANDOM() % RAND_MAX) / RAND_MAX -.5,
+                                  (RANDOM() % RAND_MAX) / RAND_MAX -.5],
+                      SELF.y := [])
+                      );
+
+test := PROJECT(test0, TRANSFORM(RECORDOF(LEFT), SELF.y := targetFunc(LEFT.x[1], LEFT.x[2], LEFT.x[3], LEFT.x[4], LEFT.x[5]), SELF := LEFT));
+
+// Break the training and test data into X (independent) and Y (dependent) data sets.
+// Format as NumericField data.
+
+trainX0 := NORMALIZE(train, featureCount, TRANSFORM(NumericField,
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.x[COUNTER]));
+trainY0 := NORMALIZE(train, classCount, TRANSFORM(NumericField,
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.y[COUNTER]));
+trainX1 := Tensor.R4.dat.fromMatrix(TrainX0);
+trainY1 := Tensor.R4.dat.fromMatrix(TrainY0);
+
+trainX := Tensor.R4.MakeTensor([0, featureCount], trainX1, limitNodes:=2);
+trainY := Tensor.R4.MakeTensor([0, classCount], trainY1, limitNodes:=2);
+
+maxInputWi := MAX(trainX, wi);
+// Change the wi's for outputs (y) so that they are after the input wi's
+y1 := PROJECT(trainY, TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi + maxInputWi, SELF := LEFT), LOCAL);
+aligned := Tensor.R4.AlignTensors(trainX + y1, limitNodes:=2);
+// Now change the Y's wi back to the original numbers
+xAl := aligned(wi <= maxInputWi);
+yAl := PROJECT(aligned(wi > maxInputWi), TRANSFORM(RECORDOF(LEFT), SELF.wi := LEFT.wi - maxInputWi, SELF := LEFT), LOCAL);
+
+
+// OUTPUT(xAl, NAMED('XAL'));
+// OUTPUT(YAl, NAMED('YAL'));
+// OUTPUT(trainX0, NAMED('X1_0'));
+// OUTPUT(trainY0, NAMED('y1_o'));
+OUTPUT(trainX, NAMED('X'));
+OUTPUT(trainY, NAMED('y'));
+
+testX := NORMALIZE(test, featureCount, TRANSFORM(NumericField, // 5
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.x[COUNTER]));
+testY := NORMALIZE(test, classCount, TRANSFORM(NumericField,  // 3
+                            SELF.wi := 1,
+                            SELF.id := LEFT.id,
+                            SELF.number := COUNTER,
+                            SELF.value := LEFT.y[COUNTER]));
+
+// OUTPUT(count(trainY[1].densedata), Named('TestY1_Count'));
+// OUTPUT(count(trainY[2].densedata), Named('TestY2_Count'));
+// ldef provides the set of Keras layers that form the neural network.  These are
+// provided as strings representing the Python layer definitions as would be provided
+// to Keras.  Note that the symbol 'tf' is available for use (import tensorflow as tf), as is
+// the symbol 'layers' (from tensorflow.keras import layers).
+ldef := ['''layers.Dense(16, activation='tanh', input_shape=(5,))''',
+          '''layers.Dense(16, activation='relu')''',
+          '''layers.Dense(3, activation='softmax')'''];
+
+// compileDef defines the compile line to use for compiling the defined model.
+// Note that 'model.' is implied, and should not be included in the compile line.
+compileDef := '''compile(optimizer=tf.keras.optimizers.SGD(.05),
+              loss=tf.keras.losses.categorical_crossentropy,
+              metrics=['accuracy'])
+              ''';
+
+// Note that the order of the GNNI functions is maintained by passing tokens returned from one call
+// into the next call that is dependent on it.
+// For example, s is returned from GetSession().  It is used as the input to DefineModels(...) so
+// that DefineModels() cannot execute until GetSession() has completed.
+// Likewise, mod, the output from GetSession() is provided as input to Fit().  Fit in turn returns
+// a token that is used by GetLoss(), EvaluateMod(), and Predict(), which are only dependent on Fit()
+// having completed, and are not order dependent on one another.
+
+// GetSession must be called before any other functions
+s := GNNI.GetSession();
+// Define model is dependent on the Session
+//   ldef contains the Python definition for each Keras layer
+//   compileDef contains the Keras compile statement.
+mod := GNNI.DefineModel(s, ldef, compileDef);
+// GetWeights returns the initialized weights that have been synchronized across all nodes.
+wts := GNNI.GetWeights(mod);
+
+OUTPUT(wts, NAMED('InitWeights'));
+
+// Fit trains the models, given training X and Y data.  BatchSize is not the Keras batchSize,
+// but defines how many records are processed on each node before synchronizing the weights
+// Note that we use the NF form of Fit since we are using NumericField for I / o.
+//mod2 := GNNI.FitNF(mod, trainX, trainY, batchSize := batchSize, numEpochs := numEpochs);
+
+mod2 := GNNI.nNodeFit(mod, trainX, trainY, batchSize_ := batchSize, numEpochs_ := numEpochs, limitNodes_ := 2);
+
+OUTPUT(mod2, NAMED('mod2'));
+
+// GetLoss returns the average loss for the final training epoch
+losses := GNNI.GetLoss(mod2);
+
+// EvaluateNF computes the loss, as well as any other metrics that were defined in the Keras
+// compile line.  This is the NumericField form of EvaluateMod.
+metrics := GNNI.EvaluateNF(mod2, testX, testY);
+
+OUTPUT(metrics, NAMED('metrics'));
+
+// PredictNF computes the neural network output given a set of inputs.
+// This is the NumericField form of Predict. Note that these predictions are
+// effectively the probabilities for each class (as output from softmax in the
+// final NN layer).  If we had used Tensors rather than NumericField, we
+// could convert to a class label by using Utils.FromOneHot, or
+// Utils.Probabilities2Class.
+preds := GNNI.PredictNF(mod2, testX);
+
+OUTPUT(testY, ALL, NAMED('testDat'));
+OUTPUT(preds, NAMED('predictions'));


### PR DESCRIPTION
 #hpcc-29578

**Tasks:**
 - [ ] Assert the same number of nodes are selected function

**Question:**
 - [x] How to differentiate last n nodes vs. first n nodes.
 A: we don't need to differentiate. The fit function is slow in a distributed environment, so we just wanted to run it on a single machine
 
**Changes required on:**
// GNNI >> Fit >>*** TODO: setweight should set weight to all nodes; not just training nodes; in the final step only
// Keras >> _Tens2NpList(tens, recordOriented = False):
    


```
/opt/HPCCSystems/9.0.6/clienttools/bin/ecl bundle install --update --force /Users/nkandel/hpcc/GNN
```